### PR TITLE
Feature/controlled list search

### DIFF
--- a/app/api-handlers/controlled-lists.js
+++ b/app/api-handlers/controlled-lists.js
@@ -18,47 +18,33 @@ function apiCallList(list, search) {
     winston.info('==> apiCallList() url: ' + endPoint);
 
     var apiData = null;
-    if (list)  {
+    if (list) {
         if (search) {
-            apiData = { url: encodeURI(endPoint + '/' + list + '?field=' + search.field + '&contains=' + search.contains) };
+            apiData = {url: encodeURI(endPoint + '/' + list + '?contains=' + search.contains)};
         } else {
-            apiData = { url: endPoint + '/' + list };
+            apiData = {url: endPoint + '/' + list};
         }
     } else {
-        apiData = { url: endPoint };
+        apiData = {url: endPoint};
     }
 
     return new Promise(function (resolve, reject) {
         Request.get(apiData, function (err, httpResponse) {
             if (!httpResponse) {
-                reject({
-                    isUserError: true,
-                    message: 'No response'
-                });
+                reject(new Error("Internal Error: No response from API"));
             } else if (err) {
-                reject({
-                    isUserError: true,
-                    message: 'Request Error',
-                    messageDetail: err.message
-                });
+                reject(err);
             } else {
+
                 if (httpResponse.statusCode !== 200) {
-                    reject({
-                        isUserError: true,
-                        message: 'Request Error: ' + httpResponse.statusCode,
-                        messageDetail: httpResponse.statusMessage
-                    });
+                    reject(new Error(`Internal Error: Unexpected response ${httpResponse.statusCode} from API: ${httpResponse.statusMessage}`));
                 } else {
                     try {
                         var parsedJson = JSON.parse(httpResponse.body);
                         // Return the result as an array
                         resolve(parsedJson);
                     } catch (err) {
-                        reject({
-                            isUserError: true,
-                            message: 'Invalid JSON Response: ',
-                            messageDetail: err.message
-                        });
+                        reject(err);
                     }
                 }
             }
@@ -104,7 +90,7 @@ module.exports.getListData = function (list, search) {
  * @param displayHeaders - an array the data object names
  * @returns {Array} The output data structure required by display-list.html
  */
-module.exports.pageExtractor = function(listData, displayHeaders) {
+module.exports.pageExtractor = function (listData, displayHeaders) {
     var rows = [];
     for (var r = 0; r < listData.length; r++) {
         var cols = [];
@@ -126,7 +112,7 @@ module.exports.pageExtractor = function(listData, displayHeaders) {
  * @param displayHeaders - an array the data object names
  * @returns {Array} The output data structure required by the CSV processor
  */
-module.exports.csvExtractor = function(listData, displayHeaders) {
+module.exports.csvExtractor = function (listData, displayHeaders) {
     var rows = [];
     for (var r = 0; r < listData.length; r++) {
         var cols = [];
@@ -153,7 +139,7 @@ module.exports.csvExtractor = function(listData, displayHeaders) {
 module.exports.getListProcessor = function (extractorFunction, list, processor, search) {
     return new Promise(function (resolve, reject) {
         module.exports.getListMetaData().then(function (result) {
-            var listMetaData = { displayHeaders : undefined };
+            var listMetaData = {displayHeaders: undefined};
             listMetaData = result[list];
             var tableHeadings = [];
             if (listMetaData && listMetaData.displayHeaders) {

--- a/app/routeHandlers/lookup/ListHandler.js
+++ b/app/routeHandlers/lookup/ListHandler.js
@@ -4,6 +4,9 @@ const stringify = require('csv').stringify;
 let handler = require('../../api-handlers/controlled-lists.js');
 
 
+let getNavigationSource = function (request) {
+    return request.query.src || request.info.referrer || "/controlled-lists";
+};
 
 module.exports = {
     /*
@@ -52,7 +55,7 @@ module.exports = {
                 tableHeadings: header,
                 rows: data,
                 clear: false,
-                back: request.info.referrer || "/controlled-lists"
+                src: getNavigationSource(request)
             });
         }).catch(() => reply.redirect("/controlled-lists"));
     },
@@ -86,7 +89,7 @@ module.exports = {
                         tableHeadings: headings,
                         rows: data,
                         clear: true,
-                        back: request.info.referrer || "/controlled-lists"
+                        src: getNavigationSource(request),
                         messages: messages,
                         query: {
                             string: searchString,

--- a/app/routeHandlers/lookup/ListHandler.js
+++ b/app/routeHandlers/lookup/ListHandler.js
@@ -1,7 +1,9 @@
 'use strict';
 const winston = require("winston");
 const stringify = require('csv').stringify;
-var handler = require('../../api-handlers/controlled-lists.js');
+let handler = require('../../api-handlers/controlled-lists.js');
+
+
 
 module.exports = {
     /*
@@ -18,16 +20,22 @@ module.exports = {
     getHandler: function (request, reply) {
         winston.info('==> /controlled-lists');
         handler.getListMetaData().then(function (result) {
-            var items = [];
-            for (var key in result) {
+            let items = [];
+            for (let key in result) {
                 if (result.hasOwnProperty(key)) {
-                    items.push(result[key]);
+                    let item = result[key];
+                    if (item.displayHeaders.length > 0) {
+                        items.push(item);
+                    }
                 }
             }
             reply.view('data-returns/controlled-lists', {
                 controlledLists: items
             });
-        }).catch(winston.error);
+        }).catch((err) => {
+            winston.error(err);
+            reply.redirect('data-returns/failure');
+        });
     },
 
     /**
@@ -36,9 +44,9 @@ module.exports = {
      * @param reply
      */
     getDisplayHandler: function (request, reply) {
-        var list = request.query.list;
+        let list = request.query.list;
         winston.info('==> /display-list ' + list);
-        handler.getListProcessor(handler.pageExtractor, list, function(metadata, header, data) {
+        handler.getListProcessor(handler.pageExtractor, list, function (metadata, header, data) {
             reply.view('data-returns/display-list', {
                 listMetaData: metadata,
                 tableHeadings: header,
@@ -50,25 +58,53 @@ module.exports = {
     },
 
     getDisplayHandlerWithSearch: function (request, reply) {
-        var list = request.query.list;
+        let list = request.query.list;
         // if no search term pass control back to the full list handler
-        if (request.payload.search === '') {
+        let searchString = request.query.q || '';
+        searchString = searchString.trim();
+        if (searchString === '') {
             module.exports.getDisplayHandler(request, reply);
         } else {
             handler.getListMetaData().then(function (metadata) {
-                handler.getListProcessor(handler.pageExtractor, list, function (metadata, header, data) {
-                    winston.info(`==> /display-list-search list=${list} search=${metadata.defaultSearch} for search=${request.payload.search}`);
+                let resultHandler = function (metadata, headings, data) {
+                    winston.info(`==> /display-list-search list=${list} search=${metadata.searchFields} for search=${searchString}`);
+                    let searchTerms = searchString.split(/\s+/);
+                    let entryText = data.length === 1 ? "entry" : "entries";
+                    let searchTermStrings = searchTerms.map(t => `"${t}"`).join(", ").replace(/,(?!.*,)/gmi, ' or');
+                    let searchableHeadings = metadata.searchFields.map(t => metadata.displayHeaders.find(d => d.field === t));
+
+                    let messages = [];
+                    messages.push(`Found ${data.length} ${entryText} matching ${searchTermStrings}`);
+
+                    if (data.length === 0 && headings.length > 1 && searchableHeadings.length < headings.length) {
+                        let searchableHeadingNames = searchableHeadings.map(t => `"${t.header}"`).join(", ").replace(/,(?!.*,)/gmi, ' and');
+                        messages.push(`You can search for entries under the ${searchableHeadingNames} ${searchableHeadings.length === 1 ? 'heading' : 'headings'}`);
+                    }
+
                     reply.view('data-returns/display-list', {
                         listMetaData: metadata,
-                        tableHeadings: header,
+                        tableHeadings: headings,
                         rows: data,
                         clear: true,
                         back: request.info.referrer || "/controlled-lists"
+                        messages: messages,
+                        query: {
+                            string: searchString,
+                            terms: searchTerms
+                        }
                     });
-                }, {field: metadata[list].defaultSearch, contains: request.payload.search}).catch(function (err) {
-                    throw err.message;
+                };
+
+                return handler.getListProcessor(handler.pageExtractor, list, resultHandler, {contains: searchString}).catch((err) => {
+                    winston.error(err);
+                    reply.view('data-returns/display-list', {
+                        messages: ["A problem occurred while attempting to filter the list, please try again later."]
+                    });
                 });
-            }).catch(() => reply.redirect("/controlled-lists"));
+            }).catch((err) => {
+                winston.error(err);
+                reply.redirect("/controlled-lists")
+            });
         }
     },
 
@@ -78,25 +114,25 @@ module.exports = {
      * @param request
      * @param reply
      */
-    getCSVHandler: function(request, reply) {
+    getCSVHandler: function (request, reply) {
         if (!request.params || !request.params.list) {
             throw 'Excepted - filename';
         }
 
-        var filename = request.params.list + '.csv';
+        let filename = request.params.list + '.csv';
         winston.info('==> /csv-list ' + filename);
 
-        handler.getListProcessor(handler.csvExtractor, request.params.list, function(metadata, header, data) {
+        handler.getListProcessor(handler.csvExtractor, request.params.list, function (metadata, header, data) {
             let columns = header.map(h => h.description);
             let rows = data.map(r => r.row);
-            stringify(rows, { header: true, columns: columns, quoted: true }, function(err, output) {
+            stringify(rows, {header: true, columns: columns, quoted: true}, function (err, output) {
                 if (err) {
                     winston.error("Failed to write downloadable CSV for controlled lists.", err);
                     reply.redirect('data-returns/failure');
                 } else {
                     // UTF8 BOM is required so as not to corrupt special UTF8 characters in Excel.
                     const UTF8_BOM = "\uFEFF";
-                    var response = reply(UTF8_BOM + output)
+                    let response = reply(UTF8_BOM + output)
                         .header('Content-Type', 'text/csv; charset=utf-8;')
                         .header('content-disposition', `attachment; filename=${filename};`)
                         .hold();

--- a/app/routes.js
+++ b/app/routes.js
@@ -208,11 +208,6 @@ let handlers = [
     {
         method: 'GET',
         path: '/display-list',
-        handler: listHandler.getDisplayHandler
-    },
-    {
-        method: 'POST',
-        path: '/display-list-search',
         handler: listHandler.getDisplayHandlerWithSearch
     },
     {

--- a/app/views/data-returns/display-list.html
+++ b/app/views/data-returns/display-list.html
@@ -1,5 +1,10 @@
 {{<layout}}
 
+{{$head}}
+    {{>head}}
+    {{$commonHead}}{{/commonHead}}
+    <script src="/public/javascripts/jquery.mark.min.js" type="text/javascript"></script>
+{{/head}}
 
 {{$title}}{{listMetaData.description}} allowed values{{/title}}
 
@@ -82,6 +87,14 @@
     </table>
     {{/rows.length}}
 
+    {{#query.terms.length}}
+    <script type="text/javascript">
+        var hlClasses = "{{listMetaData.searchFields}}";
+        hlClasses = hlClasses.split(",").map(function(field) {return "td." + field}).join(",");
+        var cells = $("#controlled-list-table").find(hlClasses);
+        cells.mark("{{query.terms}}".split(","));
+    </script>
+    {{/query.terms.length}}
 </main>
 {{/content}}
 {{/layout}}

--- a/app/views/data-returns/display-list.html
+++ b/app/views/data-returns/display-list.html
@@ -11,7 +11,7 @@
 {{$content}}
 <main id="content" role="main">
     {{{feedbackbanner}}}
-    <a id="back.btn"  onclick="history.back(); return false;" href="{{back}}" class="link-back">Go back</a>
+    <a id="back.btn" href="{{src}}" class="link-back">Go back</a>
     <div class="grid-row">
         <div class="column-two-thirds">
             <h1 class="heading-large" style="padding-top: 0; margin-top: 0;"><span id="title">{{$title}}{{/title}}</span></h1>

--- a/app/views/data-returns/display-list.html
+++ b/app/views/data-returns/display-list.html
@@ -1,6 +1,7 @@
 {{<layout}}
 
-{{$title}}{{listMetaData.description}}{{/title}}
+
+{{$title}}{{listMetaData.description}} allowed values{{/title}}
 
 {{$content}}
 <main id="content" role="main">
@@ -8,37 +9,47 @@
     <a id="back.btn"  onclick="history.back(); return false;" href="{{back}}" class="link-back">Go back</a>
     <div class="grid-row">
         <div class="column-two-thirds">
-        <h1 class="heading-large"><span id="title">{{$title}}{{/title}} allowed values</span></h1>
-            <p>You can only use these values and they must be spelt exactly as they are in this list. If there are alternative values, you can also use those. When you upload your data we’ll convert alternatives into the main value.</p>
+            <h1 class="heading-large" style="padding-top: 0; margin-top: 0;"><span id="title">{{$title}}{{/title}}</span></h1>
+            <p>You can only use these values and they must be spelt exactly as they are in this list. If there are
+                alternative values, you can also use those. When you upload your data we’ll convert alternatives into
+                the main value.</p>
             <p><a href="/csv/{{listMetaData.path}}">Download {{$title}}{{/title}} list (CSV)</a></p>
+
         </div>
         <div class="column-third">
             <h2 class="heading-small">Version 1.0</h2>
-                <details>
-                    <summary><span class="summary">How we deal with changes</span></summary>
-                    <div class="panel panel-border-narrow">
-                        <p>We aim to keep these allowed values fixed. This should allow you to adapt your software systems to use these values. If we need to make changes, we won't remove values but we may add missing values as alternatives or correct any mistakes.</p>
-                    </div>
-                </details>
-            <!-- REMOVED SEARCH
-            <div class="form-group">
-                <p><a id="back.btn" onclick="history.back(); return false;" href="{{back}}" class="button">Go back</a></p>
-            </div>
-            <div class="form-group search-list">
-                <form action="display-list-search?list={{listMetaData.path}}" method="post">
-                    <input type="hidden" name="crumb" value="{{crumb}}"/>
-                    <label class="form-label" for="search">Filter this list:</label>
-                    <input id="search" class="form-control" type="text" name="search">
-                    <input class="button button-secondary" type="submit" value="Submit">
-                    {{#clear}}
-                    <a id="clear" class="button button-secondary" href="/display-list?list={{listMetaData.path}}">Clear filter</a>
-                    {{/clear}}
-                </form>
-            </div>
-            -->
+            <details>
+                <summary><span class="summary">How we deal with changes</span></summary>
+                <div class="panel panel-border-narrow">
+                    <p>We aim to keep these allowed values fixed. This should allow you to adapt your software systems
+                        to use these values. If we need to make changes, we won't remove values but we may add missing
+                        values as alternatives or correct any mistakes.</p>
+                </div>
+            </details>
         </div>
     </div>
+    <div class="form-group search-list">
+        <form method="get">
+            <div class="form-hint">Filter this list:</div>
+            <input id="search" name="q" class="form-control" type="text" value="{{query.string}}"/>
+            <input class="button" type="submit" value="Find">
+            {{#clear}}
+            <a id="clear" class="button button-secondary" href="/display-list?list={{listMetaData.path}}&src={{src}}">Clear</a>
+            {{/clear}}
+            <input type="hidden" name="list" value="{{listMetaData.path}}"/>
+            <input type="hidden" name="src" value="{{src}}"/>
+        </form>
+    </div>
 
+    {{#messages.length}}
+    {{#messages}}
+    <div class="panel panel-border-wide">
+        <p>{{.}}</p>
+    </div>
+    {{/messages}}
+    {{/messages.length}}
+
+    {{#rows.length}}
     <table id="controlled-list-table" class="{{description}} table-control">
         <thead>
         <tr>
@@ -47,19 +58,21 @@
             {{/tableHeadings}}
         </tr>
         </thead>
-        <tbody>
+        <tbody class="controlled-list-table-body">
         {{#rows}}
         <tr>
             {{#row}}
             <td class="{{cellCls}}">
                 {{#item.length}}
                 <ul style="white-space: nowrap;">
-                    {{#item}}<li>{{.}}</li>{{/item}}
+                    {{#item}}
+                    <li>{{.}}</li>
+                    {{/item}}
                 </ul>
                 {{/item.length}}
 
                 {{^item.length}}
-                    {{item}}
+                {{item}}
                 {{/item.length}}
             </td>
             {{/row}}
@@ -67,6 +80,7 @@
         {{/rows}}
         </tbody>
     </table>
+    {{/rows.length}}
 
 </main>
 {{/content}}

--- a/app/views/data-returns/eaid-lookup.html
+++ b/app/views/data-returns/eaid-lookup.html
@@ -88,11 +88,11 @@
     </div>
 
 
-    {{#query.terms}}
+    {{#query.terms.length}}
     <script type="text/javascript">
-        $(".search-result-entry").mark("{{.}}".split(","));
+        $(".search-result-entry").mark("{{query.terms}}".split(","));
     </script>
-    {{/query.terms}}
+    {{/query.terms.length}}
 
     {{/results.length}}
 </main>


### PR DESCRIPTION
**Allow controlled lists to be searched using multiple fields**
- Lists can now be searched by alternative identifiers and other important fields (e.g. CAS)
- Moved search from POST to GET method
- Standardised API error handling
- Fixed missing handler for Promise.reject causing hapi error

**Added result highlighting to controlled list filter**
- Added result highlighting using same mechanism as EA_ID lookup
- Improved hook to initialise highlighting on EA_ID lookup

**Fixed "Go back" link functionality on controlled list pages**