### PR TITLE
Replace 'e.g.' and fix mistake in error snippet for Mon_Point

### DIFF
--- a/app/error-templates/corrections/DR9060-Incorrect.html
+++ b/app/error-templates/corrections/DR9060-Incorrect.html
@@ -1,7 +1,4 @@
 <div class="CorrectionIncorrect">
-    <p>You must refer to the sampling or emission point described in your permit or licence (eg Boreholes 1) to complete
-        this field.</p>
-
-    <p>Make sure your reference only contains letters, spaces and numbers. Remove any symbols and unnecessary
-        commas.</p>
+    <p>The Mon_Point value should only contain letters, spaces or numbers.</p>
+    <p>Remove any other symbols even if they are used in your permit or licence.</p>
 </div>

--- a/app/error-templates/corrections/DR9060-Missing.html
+++ b/app/error-templates/corrections/DR9060-Missing.html
@@ -1,4 +1,3 @@
 <div class="CorrectionMissing">
-    <p>You cannot leave this field blank. You must refer to the sampling or emission point described in your permit or
-        licence (eg Boreholes 1) to complete this field.</p>
+    <p>You must enter a monitoring point reference under Mon_Point. This will be the sampling or emission point described in your permit or licence, for example 'Boreholes 1'.</p>
 </div>

--- a/app/error-templates/corrections/DR9090-Incorrect.html
+++ b/app/error-templates/corrections/DR9090-Incorrect.html
@@ -1,9 +1,5 @@
 <div class="CorrectionIncorrect">
-    <p>If a reference period is specified in your permit or licence (eg, 24 hour total) you should send data for this
-        field.</p>
-
-    <p>You must select an entry from the reference period controlled list.</p>
-
-    <p>You can leave this field blank if there are no reference period requirements stated in your permit or
-        licence.</p>
+    <p>If a reference period is specified in your permit or licence, for example '24 hour total', you should send data for this field.</p>
+    <p>You must select a value from the reference period controlled list.</p>
+    <p>You can leave this field blank if there are no reference period requirements stated in your permit or licence.</p>
 </div>


### PR DESCRIPTION
When fixing 'eg' I noticed that the error text contained text from the 'missing' error state so I removed it and reworded the message to cover the case where permit text contains a symbol (for example a '/').