### PR TITLE
Update error snippets to make column heading text consistent DIY-561

### DIFF
--- a/app/error-templates/data-structure-errors/DR0400.html
+++ b/app/error-templates/data-structure-errors/DR0400.html
@@ -1,2 +1,2 @@
-<h2 class="heading-medium error-summary-heading">Your file isn’t saved as CSV</h2>
-<p><a href="{{links.CreateAndSaveCSVFile}}" rel="noopener noreferrer" target="DRHELPPAGE">Save your file as CSV (opens new window)</a> and try again.</p>
+<h2 class="heading-medium error-summary-heading">Your file isn't saved as CSV</h2>
+<p>Read the <a href="{{links.HowToFormatEnvironmentAgencyData}}">data formatting rules</a> to find out how to save your file as CSV then try again.</p>

--- a/app/error-templates/data-structure-errors/DR0450.html
+++ b/app/error-templates/data-structure-errors/DR0450.html
@@ -1,4 +1,3 @@
 <h2 class="heading-medium error-summary-heading">There’s a problem with your CSV file</h2>
-<p>We can’t read your CSV file. This might be because you’ve used an extra comma in a field, for example, site name - without adding quotation marks to separate out the data. Or you might have missed a field heading.</p>
-<p>Read the help page on how to <a href="{{links.CreateAndSaveCSVFile}}" rel="noopener noreferrer" target="DRHELPPAGE">create and save a CSV file (opens new window)</a>.</p>
-<p>Find out more about <a href="{{links.HowToFormatEnvironmentAgencyData}}" rel="noopener noreferrer" target="DRHELPPAGE">data returns field headings (opens new window)</a>.</p>
+<p>We can’t read your CSV file. This might be because you’ve used an extra comma in a field, for example, site name, without adding quotation marks to separate out the data. Or you might have missed a column heading.</p>
+<p>Read the <a href="{{links.HowToFormatEnvironmentAgencyData}}">data formatting rules</a> to find out how to create a CSV file and the correct column headings to use.</p>

--- a/app/error-templates/data-structure-errors/DR0500.html
+++ b/app/error-templates/data-structure-errors/DR0500.html
@@ -1,3 +1,3 @@
 <h2 class="heading-medium error-summary-heading">Your file is empty</h2>
 <p>Make sure you’ve submitted the right file and try again.</p>
-<p>Read help on how to <a href="{{links.CreateAndSaveCSVFile}}" rel="noopener noreferrer" target="DRHELPPAGE">create and save a CSV file (opens new window)</a>.</p>
+<p>Read the <a href="{{links.HowToFormatEnvironmentAgencyData}}">data formatting rules</a> to find out how to save your file as CSV then try again.</p>

--- a/app/error-templates/data-structure-errors/DR0550.html
+++ b/app/error-templates/data-structure-errors/DR0550.html
@@ -1,3 +1,3 @@
 <h2 class="heading-medium error-summary-heading">Your file is too large</h2>
-<p>Your file size is above {{config.csv.maxFileSizeMb}}MB.</p>
-<p>You need to reduce your file size to send data to the Environment Agency using the service.</p>
+<p>Your file size is greater than {{config.csv.maxFileSizeMb}}MB.</p>
+<p>You should split the rows of data over several smaller files and upload them together.</p>

--- a/app/error-templates/data-structure-errors/DR0600.html
+++ b/app/error-templates/data-structure-errors/DR0600.html
@@ -1,2 +1,2 @@
 <h2 class="heading-medium error-summary-heading">Your file is unsafe</h2>
-<p>Your file hasn’t passed the security check so it might contain a virus or other suspicious content. Check your file and <a href="#">start again</a>.</p>
+<p>Your file hasn't passed the security check so it might contain a virus or other suspicious content. Check your file and <a href="#">start again</a>.</p>

--- a/app/error-templates/data-structure-errors/DR0820.html
+++ b/app/error-templates/data-structure-errors/DR0820.html
@@ -1,5 +1,5 @@
-<h2 class="heading-medium error-summary-heading">Your data return is incomplete</h2>
-<p>Your return might be missing data under these field headings:</p>
+<h2 class="heading-medium error-summary-heading">Your data file is incomplete</h2>
+<p>Your file might be missing data under these column headings:</p>
 <ul class="list list-bullet">
     <li>EA_ID</li>
     <li>Site_Name</li>
@@ -8,4 +8,4 @@
     <li>Mon_Date</li>
     <li>Parameter</li>
 </ul>
-<p>Find out about <a href="{{links.HowToFormatEnvironmentAgencyData}}" rel="noopener noreferrer" target="DRHELPPAGE">formatting all your data to meet EA standards (opens new window)</a>.</p>
+<p>Read the <a href="{{links.HowToFormatEnvironmentAgencyData}}">data formatting rules</a> to check you are reporting your data correctly.</p>

--- a/app/error-templates/data-structure-errors/DR0840.html
+++ b/app/error-templates/data-structure-errors/DR0840.html
@@ -1,4 +1,3 @@
-<h2 class="heading-medium error-summary-heading">You need to check your field headings</h2>
-<p>Your file contains field headings that do not meet EA data formatting standards.</p>
-<p>Your headings must match those given in the EA guidance on how to format your data returns.</p>
-<p>Find out about <a href="{{links.HowToFormatEnvironmentAgencyData}}" rel="noopener noreferrer" target="DRHELPPAGE">formatting all your data to meet EA standards (opens new window)</a>.</p>
+<h2 class="heading-medium error-summary-heading">The column headings aren't correct</h2>
+<p>Change the column headings in your data file so they are the same as those in the <a href="{{links.HowToFormatEnvironmentAgencyData}}">data formatting rules</a>.</p>
+<p>You must match the expected column headings exactly, with correct use of capitals and no spaces between words. For example, 'Rtn_Type' not 'Return type'.</p>

--- a/app/error-templates/data-structure-errors/DR0860.html
+++ b/app/error-templates/data-structure-errors/DR0860.html
@@ -1,7 +1,3 @@
-<h2 class="heading-medium error-summary-heading">Your data contains duplicate field headings</h2>
-<p>
-    You can only submit your data if the headings in each column are unique.
-    Check that your short field headings meet compliance monitoring requirements.
-</p>
-<p>Find out about <a href="{{links.HowToFormatEnvironmentAgencyData}}" rel="noopener noreferrer" target="DRHELPPAGE">formatting all your data to meet EA standards (opens new window)</a>.
-</p>
+<h2 class="heading-medium error-summary-heading">Your data contains duplicate column headings</h2>
+<p>You can only submit your data if the column headings are unique.</p>
+<p>Check that the column headings in your data file are the same as those in the <a href="{{links.HowToFormatEnvironmentAgencyData}}">data formatting rules</a> and are unique.</p>


### PR DESCRIPTION
This is work for DIY-561.
'Field heading' has been changed to 'column heading'.
Links no longer open in a new window.
Some text has been clarified.
We use 'data formatting rules' consistently.