### PR TITLE
Update confirmation page text to match agreed email text

### DIFF
--- a/app/views/data-returns/file-sent.html
+++ b/app/views/data-returns/file-sent.html
@@ -21,7 +21,7 @@
 
         <h2 class="heading-medium">What happens next?</h2>
 
-        <p>We’ll check your data for quality and regulatory compliance and contact you if we need to.</p>
+        <p>Your site officer will review your data. If the data is OK, we won't usually contact you. We'll contact you if we have any questions or if the data does not meet regulatory requirements.</p>
 
         <p>
             You can <a href="{{links.Choose_File_Page}}">send more data</a> or go to the


### PR DESCRIPTION
We already updated the email text but forgot to bring the confirmation page into line with that text.